### PR TITLE
specify "close connection" in request header

### DIFF
--- a/tmpo.py
+++ b/tmpo.py
@@ -262,7 +262,8 @@ class Session():
         token, = self.dbcur.fetchone()
         headers = {
             "Accept": HTTP_ACCEPT["json"],
-            "X-Token": token}
+            "X-Token": token,
+            "Connection": "close"}
         params = {
             "rid": rid,
             "lvl": lvl,
@@ -284,7 +285,8 @@ class Session():
     def _req_block(self, sid, token, rid, lvl, bid, ext):
         headers = {
             "Accept": HTTP_ACCEPT["gz"],
-            "X-Token": token}
+            "X-Token": token,
+            "Connection": "close"}
         f = self.rqs.get(
             API_TMPO_BLOCK % (self.host, sid, rid, lvl, bid),
             headers=headers,


### PR DESCRIPTION
If an instance of Session is not destroyed and reused again, the request library will reopen a new connection every time sync() is called. Old connections remain "waiting for closing". If sync() is called in regular time intervals, the system will hit the "maximum open files" limit.

This can be fixed by explicitly specifying "Connection": "close" in the request header.