### PR TITLE
Fix truncate bug in pandas 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,9 @@ target/
 
 # Vim
 *.swp
+
+# ipython notebook checkpoints
+*.ipynb_checkpoints/
+
+# tmpo cache
+.tmpo

--- a/tmpo.py
+++ b/tmpo.py
@@ -248,10 +248,9 @@ class Session():
         self._npdelta(pdsblk.index, h["head"][0])
         self._npdelta(pdsblk, h["head"][1])
         # only truncate if needed (avoids pandas bug and more efficient)
-        if head > pdsblk.index[0] or tail < pdsblk.index[-1]:
-            return pdsblk.truncate(before=head, after=tail)
-        else:
-            return pdsblk
+        # don't use pandas.truncate with integer indices!
+        pdsblk_truncated = pdsblk.loc[max(head, pdsblk.index[0]):min(tail, pdsblk.index[-1])] 
+        return pdsblk_truncated
 
     def _npdelta(self, a, delta):
         """Numpy: Modifying Array Values

--- a/tmpo.py
+++ b/tmpo.py
@@ -247,7 +247,11 @@ class Session():
         h = json.loads(m.group("h"))
         self._npdelta(pdsblk.index, h["head"][0])
         self._npdelta(pdsblk, h["head"][1])
-        return pdsblk.truncate(before=head, after=tail)
+        # only truncate if needed (avoids pandas bug and more efficient)
+        if head > pdsblk.index[0] or tail < pdsblk.index[-1]:
+            return pdsblk.truncate(before=head, after=tail)
+        else:
+            return pdsblk
 
     def _npdelta(self, a, delta):
         """Numpy: Modifying Array Values


### PR DESCRIPTION
I ran again in pandas trouble with the use of truncate.  My first solution (only calling truncate when really, really needed) did not work, so now I'm using the `.loc[]` method directly.  

This solves the bug I had when trying to create a series for an electricity sensor. 