### PR TITLE
raise request status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ target/
 
 # tmpo cache
 .tmpo
+
+#pycharm
+.idea/*

--- a/tmpo/__init__.py
+++ b/tmpo/__init__.py
@@ -300,6 +300,7 @@ class Session():
             params=params,
             verify=self.crt)
         r = f.result()
+        r.raise_for_status()
         fs = []
         for t in r.json():
             fs.append((t, self._req_block(


### PR DESCRIPTION
Sometimes I get JSONDecodeErrors, which are the result of an invalid server response, so that is the error that should be raised. `raise_for_status` raises an HTTP-error if the status code of the server response is not 200.
