### PR TITLE
Issue27 full delete

### DIFF
--- a/tmpo/__init__.py
+++ b/tmpo/__init__.py
@@ -43,6 +43,10 @@ SQL_SENSOR_DEL = """
     DELETE FROM sensor
     WHERE sid = ?"""
 
+SQL_TMPO_DEL = """
+    DELETE FROM tmpo
+    WHERE sid = ?"""
+
 SQL_SENSOR_ALL = """
     SELECT sid
     FROM sensor
@@ -225,6 +229,7 @@ class Session():
             SensorID
         """
         self.dbcur.execute(SQL_SENSOR_DEL, (sid,))
+        self.dbcur.execute(SQL_TMPO_DEL, (sid,))
 
     @dbcon
     def sync(self, *sids):

--- a/tmpo/__init__.py
+++ b/tmpo/__init__.py
@@ -232,6 +232,18 @@ class Session():
         self.dbcur.execute(SQL_TMPO_DEL, (sid,))
 
     @dbcon
+    def reset(self, sid):
+        """
+        Removes all tmpo blocks for a given sensor, but keeps sensor table
+        intact, so sensor id and token remain in the database.
+
+        Parameters
+        ----------
+        sid : str
+        """
+        self.dbcur.execute(SQL_TMPO_DEL, (sid,))
+
+    @dbcon
     def sync(self, *sids):
         """
         Synchronise data

--- a/tmpo/__init__.py
+++ b/tmpo/__init__.py
@@ -1,5 +1,5 @@
 __title__ = "tmpo"
-__version__ = "0.2.8"
+__version__ = "0.2.9"
 __build__ = 0x000100
 __author__ = "Bart Van Der Meerssche"
 __license__ = "MIT"
@@ -396,7 +396,7 @@ class Session():
         timestamp = first_block[2]
         if not epoch:
             timestamp = pd.Timestamp.utcfromtimestamp(timestamp)
-            timestamp = timestamp.tz.localize('UTC')
+            timestamp = timestamp.tz_localize('UTC')
         return timestamp
 
     def last_timestamp(self, sid, epoch=False):

--- a/tmpo/__init__.py
+++ b/tmpo/__init__.py
@@ -1,5 +1,5 @@
 __title__ = "tmpo"
-__version__ = "0.2.9"
+__version__ = "0.2.10"
 __build__ = 0x000100
 __author__ = "Bart Van Der Meerssche"
 __license__ = "MIT"


### PR DESCRIPTION
closes #27

`remove` now removes data from the table `sensor` and `tmpo`. So it is a full delete.

New method `reset` only deletes tmpo blocks, so it does the same as `remove` + `add` (but you don’t need to have the token).

(I don’t know why the old commits still show up, again an issue with git I suppose)